### PR TITLE
Add begin() to builder

### DIFF
--- a/src/Notifynder/Builder/NotifynderBuilder.php
+++ b/src/Notifynder/Builder/NotifynderBuilder.php
@@ -47,6 +47,18 @@ class NotifynderBuilder implements ArrayAccess
         $this->notifynderCategory = $notifynderCategory;
     }
 
+   /**
+     * Start with a fresh empty notification
+     *
+     * @return $this
+     */
+    public function begin() 
+    {
+        $this->notifications = [];
+
+        return $this;
+    }
+
     /**
      * Set who will send the notification
      *


### PR DESCRIPTION
I discovered a bug when using the same Notifynder instance to send repeated notifications. Attempting to send a single notification after using loop() to send an array of notifications causes the notifications array to be caught in an inconsistent state where unidimensional properties get added to the multidimensional array.

To duplicate: Use loop() on an instance, then send a single notification. See exception thrown in NotifynderBuilder::toArray().

This patch provides a begin() method which empties the notification array so the Notifynder instance can be safely reused.
